### PR TITLE
Remove prices and unify WhatsApp contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm run preview
 - Заголовок и description: `index.html` в `<title>` и `<meta name="description">`.
 
 ### Где править контент
-- Тексты, цены, телефоны: `src/constants.js`
+- Тексты и телефоны: `src/constants.js`
 - Разметка секций: `src/App.jsx`
 
 ### Тесты

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,7 +67,6 @@ export default function App() {
           </div>
           <nav className="hidden sm:flex items-center gap-6 text-sm">
             <a href="#services" className="hover:text-amber-700">Услуги</a>
-            <a href="#prices" className="hover:text-amber-700">Цены</a>
             <a href="#faq" className="hover:text-amber-700">FAQ</a>
             <a href="#contacts" className="hover:text-amber-700">Контакты</a>
           </nav>
@@ -182,8 +181,7 @@ export default function App() {
                 <h3 className="font-medium">{s.title}</h3>
               </div>
               <p className="mt-3 text-sm text-neutral-600 leading-relaxed">{s.desc}</p>
-              <div className="mt-4 flex items-center justify-between">
-                <span className="text-[15px] font-medium text-neutral-800">{s.price}</span>
+              <div className="mt-4 flex justify-end">
                 <button
                   onClick={() => {
                     track("package_select");
@@ -196,55 +194,6 @@ export default function App() {
               </div>
             </article>
           ))}
-        </div>
-      </section>
-
-      {/* PRICES */}
-      <section id="prices" className="bg-white/60 border-y border-neutral-200 scroll-mt-24">
-        <div className="max-w-6xl mx-auto px-4 py-14">
-          <h2 className="text-2xl sm:text-3xl font-semibold">Прайс</h2>
-          <div className="mt-6 grid md:grid-cols-3 gap-6">
-            {[{
-              name: "Урок (1 час)",
-              price: "2 000 ₽",
-              features: ["Микрогруппа до 2 человек", "Инструктор рядом", "Шлем и защита"],
-              badge: "Популярно",
-            }, {
-              name: "Прогулка по полям/лесу (1 час)",
-              price: "3 000 ₽",
-              features: ["Безопасный маршрут", "Чай после занятия", "Фото на телефон"],
-              badge: "Хит",
-            }, {
-              name: "Урок с тренером (манеж)",
-              price: "3 500 ₽",
-              features: ["Индивидуальная программа", "Отработка посадки", "Домашнее задание"],
-            }].map((p, i) => (
-              <div key={i} className={`rounded-2xl border p-6 bg-white shadow-sm ${p.badge ? "border-amber-400" : "border-neutral-200"}`}>
-                {p.badge && (
-                  <span className="inline-block text-[10px] uppercase tracking-wider px-2 py-1 rounded-full bg-amber-100 text-amber-900 border border-amber-300">{p.badge}</span>
-                )}
-                <h3 className="mt-2 text-lg font-semibold">{p.name}</h3>
-                <div className="mt-2 text-3xl font-semibold">{p.price}</div>
-                <ul className="mt-4 space-y-2 text-sm text-neutral-700">
-                  {p.features.map((f, j) => (
-                    <li key={j} className="flex gap-2">
-                      <CheckCircle2 className="w-4 h-4 mt-[2px]" strokeWidth={1.8} />
-                      <span>{f}</span>
-                    </li>
-                  ))}
-                </ul>
-                <button
-                  onClick={() => {
-                    track("package_select");
-                    scrollToForm(`Интересует пакет: ${p.name}`);
-                  }}
-                  className="mt-6 w-full px-4 py-2 rounded-xl bg-neutral-900 text-white text-sm"
-                >
-                  Выбрать
-                </button>
-              </div>
-            ))}
-          </div>
         </div>
       </section>
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,7 @@
 export const BRAND = 'КСК "Золотое сечение"';
 export const PHONE = "+7 (960) 713‑18‑43";
 export const PHONE_LINK = "79607131843";
-export const WHATSAPP = "79153582505";
+export const WHATSAPP = PHONE_LINK;
 export const WHATSAPP_MESSAGE =
   "Здравствуйте! Хочу записаться на урок (1 ч) в ближайшие выходные.";
 export const TELEGRAM = "Evgeny_ssh"; // опционально
@@ -13,31 +13,26 @@ export const services = [
   {
     title: "Обучение верховой езде",
     desc: "Базовые навыки для начинающих. Индивидуально или микрогруппа до 2 человек.",
-    price: "2 000 ₽ / 1 ч",
     icon: "CheckCircle2",
   },
   {
     title: "Уроки для детей",
     desc: "Спокойные и безопасные занятия под присмотром тренера.",
-    price: "по запросу",
     icon: "Baby",
   },
   {
     title: "Занятия по выездке",
     desc: "Классическая выездка, разбор ошибок, подготовка к стартам.",
-    price: "2 000 ₽ / 1 ч",
     icon: "Activity",
   },
   {
     title: "Постой лошадей (денники)",
     desc: "Просторные денники, выгула, индивидуальный рацион.",
-    price: "по запросу / мес",
     icon: "Home",
   },
   {
     title: "Тренинг лошадей",
     desc: "Работа с молодой лошадью, коррекция поведения.",
-    price: "по запросу",
     icon: "CheckCircle2",
   },
 ];


### PR DESCRIPTION
## Summary
- Drop all price references and remove pricing section
- Reuse main phone number for WhatsApp link and keep services list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b016d6c1d88328b72627573a54bd8e